### PR TITLE
Add Modal cloud configuration for OctoLens ETL

### DIFF
--- a/web/services/octolens/mentions/etl/to_jsonl.py
+++ b/web/services/octolens/mentions/etl/to_jsonl.py
@@ -52,6 +52,11 @@ def to_filesystem(
     secrets=[
         modal.Secret.from_name("dlt-octolens_mentions"),
     ],
+    cloud="aws",
+    region="us-west-2",
+    allow_concurrent_inputs=1000,
+    enable_memory_snapshot=True,
+    retries=0,
 )
 @modal.web_endpoint(
     method="POST",


### PR DESCRIPTION
Added AWS cloud configuration and performance optimizations for the Modal web endpoint. This includes setting the region to us-west-2, enabling memory snapshots, and configuring concurrent input handling to 1000 requests.
