### PR TITLE
Add LinkedIn connection model and date parser

### DIFF
--- a/web/services/linkedin/connections/connection.py
+++ b/web/services/linkedin/connections/connection.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import datetime
+
+from pydantic import (
+    BaseModel,
+    EmailStr,
+    FieldSerializationInfo,
+    HttpUrl,
+    field_serializer,
+)
+
+
+class LinkedinConnection(BaseModel):
+    """Represents a LinkedIn connection with details like name, contact info,
+    company, and connection date.
+    """
+
+    first_name: str
+    last_name: str
+    url: HttpUrl
+    email_address: EmailStr
+    company: str
+    position: str
+    connected_on: datetime.datetime
+    timestamp: datetime.datetime
+
+    @staticmethod
+    def parse_linkedin_date(
+        date_str: str,
+    ) -> str:
+        parsed_date = datetime.datetime.strptime(
+            date_str,
+            "%d %b %Y",
+        )
+        parsed_date = parsed_date.replace(
+            tzinfo=datetime.timezone.utc,
+        )
+        return parsed_date.isoformat()
+
+    @field_serializer("connected_on")
+    def serialize_priority(
+        self: LinkedinConnection,
+        connected_on: str,
+        _info: FieldSerializationInfo,
+    ) -> str:
+        del _info
+        return LinkedinConnection.parse_linkedin_date(
+            date_str=connected_on,
+        )


### PR DESCRIPTION
Adds LinkedIn Connection model for handling connection data

This PR introduces a new `LinkedinConnection` Pydantic model to represent LinkedIn connection data. The model includes fields for basic user information (name, email), professional details (company, position), and connection timestamps. It also implements custom date parsing functionality to handle LinkedIn's date format and convert it to ISO format.

Key features:
- Basic user fields: first/last name, profile URL, email
- Professional info: company and position
- Connection timing: connected_on date and timestamp
- Custom date parsing from LinkedIn's format to ISO 8601
